### PR TITLE
Add makefile for convenience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+
+.PHONY: run
+run:
+	./gradlew installDebug
+	adb shell am start -n com.cs446group18.delaywise/com.cs446group18.delaywise.MainActivity
+
+.PHONY: watch
+watch:
+	find app/src/main | entr $(MAKE) run


### PR DESCRIPTION
* `make run` runs a build and installs on adb
* `make watch` rebuilds on any file changes
This requires the [`entr` command-line utility](https://eradman.com/entrproject/), which you can get by running `brew install entr` 